### PR TITLE
README shows incorrect require() example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ To use Exceptional for node.js you must have an account at <http://getexceptiona
 Include the exceptional.js file in your application, and set your Exceptional API-KEY
 
 <pre>
- var Exceptional = require(./'exceptional');
+ var Exceptional = require(./'exceptional').Exceptional;
 
  Exceptional.API_KEY = **YOUR-API-KEY**
  </pre>


### PR DESCRIPTION
If you do ( var Exceptional = require('./exceptional'); ) without the ( .Exceptional ) on the end of the require(), you have to access exceptional methods via Exceptional.Exceptional.

Your demo.js file has the correct require() syntax, just not the README.
