### PR TITLE
Update package.json for the latest npm spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url"  : "http://github.com/contrast/exceptional-node.git"
   },
   "bugs" : {
-    "web"  : "http://github.com/contrast/exceptional-node/issues",
+    "url"  : "http://github.com/contrast/exceptional-node/issues",
     "mail" : "support@getexceptional.com"
   },
   "main"         : "./lib/exceptional",


### PR DESCRIPTION
`bugs["web"]` changed to `bugs["url"]`. This removes a warning while installing with the latest npm.
