### PR TITLE
Updated depreciated parts of node syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ There a are multiple ways you can use exceptional with your node.js app.
 * The process.uncaughtException event can be used to catch exceptions that bubble all the way up to the event loop.
 
 ```javascript
-process.addListener('uncaughtException', function(err) {
+process.on('uncaughtException', function(err) {
   Exceptional.handle(err);
 });
 ```

--- a/example/demo.js
+++ b/example/demo.js
@@ -2,7 +2,7 @@ var Exceptional = require('../lib/exceptional').Exceptional;
 
 Exceptional.API_KEY = 'your-api-key-here';
 
-process.addListener('uncaughtException', function(err) {
+process.on('uncaughtException', function(err) {
     Exceptional.handle(err);
 });
 

--- a/lib/exceptional.js
+++ b/lib/exceptional.js
@@ -59,7 +59,7 @@ var Exceptional = {
   send_error: function(doc) {
     gzip(doc, 1, function(err, data) {
 
-      var client  = HTTP.createClient(Exceptional.Port, Exceptional.Host);
+      var client  = HTTP.request(Exceptional.Port, Exceptional.Host);
 
       var headers = {
         'Host' : Exceptional.Host,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name"         : "exceptional-node",
-  "version"      : "0.1.1",
+  "version"      : "0.1.2",
   "description"  : "node.js module for getexceptional.com",
   "homepage"     : "http://getexceptional.com",
   "author"       : "Wal McConnell <support@getexceptional.com>",
@@ -8,19 +8,19 @@
   ],
   "repository" : {
     "type" : "git",
-    "url"  : "http://github.com/contrast/exceptional-node.git"
+    "url"  : "http://github.com/exceptional/exceptional-node.git"
   },
   "bugs" : {
-    "web"  : "http://github.com/contrast/exceptional-node/issues",
+    "web"  : "http://github.com/exceptional/exceptional-node/issues",
     "mail" : "support@getexceptional.com"
   },
   "main"         : "./lib/exceptional",
-  "engines"      : { "node" : ">=0.2.0" },
+  "engines"      : { "node" : ">=0.8.0" },
   "scripts"      : { "test" : "test/exceptional-test.js" },
   "dependencies" : {},
   "licenses" : [
     { "type" : "MIT",
-      "url"  : "http://github.com/contrast/exceptional-node"
+      "url"  : "http://github.com/exceptional/exceptional-node"
     }
   ]
 }


### PR DESCRIPTION
Hi everyone,
I've updated depreciated parts of the syntax to eliminate occurring warnings.
The inserted links document the current syntax.

http.createClient => http.request:
http://nodejs.org/api/http.html#http_http_createclient_port_host

process.addListener => process.on:
http://nodejs.org/docs/v0.4.1/api/process.html#process

Please review the changes.
